### PR TITLE
Remove NPM3 only support

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,9 +58,6 @@
     "fuse.js": "^2.2.0"
   },
   "main": "dist/index.js",
-  "engines": {
-    "npm": "^3.0.0"
-  },
   "config": {
     "commitizen": {
       "path": "node_modules/cz-conventional-changelog"


### PR DESCRIPTION
I'm working on NPM2 support for React Storybook.
We are getting an warning because of this module's engine deps. 

This PR will remove that warning.