### PR TITLE
Allow a string as a proptype for the width property as well

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -182,6 +182,7 @@ FuzzySearch.propTypes = {
   maxPatternLength: PropTypes.number,
   onSelect: PropTypes.func.isRequired,
   width: PropTypes.number,
+  width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   keys: PropTypes.oneOfType([PropTypes.array, PropTypes.string]),
   list: PropTypes.array.isRequired,
   location: PropTypes.number,


### PR DESCRIPTION
In order to allow for percentage widths and `'auto'` / `'inherit'` / `'inital'`. Those values already work fine, they just throw a warning now.