### PR TITLE
Add mouse click handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,31 @@ const list = [{
     />
 ```
 
+##Custom Result Template
+```js
+<FuzzySearch
+  list={list}
+  keys={['author', 'title']}
+  width={430}
+  onSelect={action('selected')}
+  resultsTemplate={(props, state, styles, mouseHandler) => {
+    return state.results.map((val, i) => {
+      const style = state.selectedIndex === i ? styles.selectedResultStyle : styles.resultsStyle;
+      return (
+        <div
+          key={i}
+          style={style}
+          onClick={() => mouseHandler(i)}
+        >
+          {val.title}
+          <span style={{ float: 'right', opacity: 0.5 }}>by {val.author}</span>
+        </div>
+      );
+    });
+  }}
+/>
+```
+
 ##Options
 
 attribute|default|description

--- a/README.md
+++ b/README.md
@@ -39,14 +39,14 @@ const list = [{
   keys={['author', 'title']}
   width={430}
   onSelect={action('selected')}
-  resultsTemplate={(props, state, styles, mouseHandler) => {
+  resultsTemplate={(props, state, styles, clickHandler) => {
     return state.results.map((val, i) => {
       const style = state.selectedIndex === i ? styles.selectedResultStyle : styles.resultsStyle;
       return (
         <div
           key={i}
           style={style}
-          onClick={() => mouseHandler(i)}
+          onClick={() => clickHandler(i)}
         >
           {val.title}
           <span style={{ float: 'right', opacity: 0.5 }}>by {val.author}</span>

--- a/README.md
+++ b/README.md
@@ -32,31 +32,6 @@ const list = [{
     />
 ```
 
-##Custom Results Template
-```js
-<FuzzySearch
-  list={list}
-  keys={['author', 'title']}
-  width={430}
-  onSelect={action('selected')}
-  resultsTemplate={(props, state, styles, clickHandler) => {
-    return state.results.map((val, i) => {
-      const style = state.selectedIndex === i ? styles.selectedResultStyle : styles.resultsStyle;
-      return (
-        <div
-          key={i}
-          style={style}
-          onClick={() => clickHandler(i)}
-        >
-          {val.title}
-          <span style={{ float: 'right', opacity: 0.5 }}>by {val.author}</span>
-        </div>
-      );
-    });
-  }}
-/>
-```
-
 ##Options
 
 attribute|default|description

--- a/README.md
+++ b/README.md
@@ -32,6 +32,31 @@ const list = [{
     />
 ```
 
+##Custom Results Template
+```js
+<FuzzySearch
+  list={list}
+  keys={['author', 'title']}
+  width={430}
+  onSelect={action('selected')}
+  resultsTemplate={(props, state, styles, clickHandler) => {
+    return state.results.map((val, i) => {
+      const style = state.selectedIndex === i ? styles.selectedResultStyle : styles.resultsStyle;
+      return (
+        <div
+          key={i}
+          style={style}
+          onClick={() => clickHandler(i)}
+        >
+          {val.title}
+          <span style={{ float: 'right', opacity: 0.5 }}>by {val.author}</span>
+        </div>
+      );
+    });
+  }}
+/>
+```
+
 ##Options
 
 attribute|default|description

--- a/src/index.js
+++ b/src/index.js
@@ -27,8 +27,7 @@ const styles = {
     padding: '12px',
     borderTop: '1px solid #eee',
     color: '#666',
-    fontSize: 14,
-    cursor: 'pointer'
+    fontSize: 14
   },
   selectedResultStyle: {
     backgroundColor: '#f9f9f9',
@@ -36,8 +35,7 @@ const styles = {
     padding: '12px',
     borderTop: '1px solid #eee',
     color: '#666',
-    fontSize: 14,
-    cursor: 'pointer'
+    fontSize: 14
   },
   resultsWrapperStyle: {
     width: '100%',
@@ -51,10 +49,10 @@ const styles = {
   }
 };
 
-const defaultResultsTemplate = (props, state, styl, clickHandler) => {
+const defaultResultsTemplate = (props, state, styl) => {
   return state.results.map((val, i) => {
     const style = state.selectedIndex === i ? styl.selectedResultStyle : styl.resultsStyle;
-    return <div key={i} style={style} onClick={() => clickHandler(i)}>{val.title}</div>;
+    return <div key={i} style={style} >{val.title}</div>;
   });
 };
 
@@ -67,7 +65,6 @@ class FuzzySearch extends Component {
     };
     this.handleChange = this.handleChange.bind(this);
     this.handleKeyDown = this.handleKeyDown.bind(this);
-    this.handleMouseClick = this.handleMouseClick.bind(this);
     this.fuse = new Fuse(props.list, this.getOptions());
   }
 
@@ -103,6 +100,14 @@ class FuzzySearch extends Component {
     };
   }
 
+  getResultsTemplate() {
+    return this.state.results.map((val, i) => {
+      const style = this.state.selectedIndex === i ?
+        styles.selectedResultStyle : styles.resultsStyle;
+      return <div key={i} style={style} >{val.title}</div>;
+    });
+  }
+
   handleChange(e) {
     this.setState({
       results: this.fuse.search(e.target.value).slice(0, this.props.maxResults - 1)
@@ -128,17 +133,6 @@ class FuzzySearch extends Component {
         selectedIndex: 0
       });
     }
-  }
-
-  handleMouseClick(clickedIndex) {
-    const { results } = this.state;
-    if (results[clickedIndex]) {
-      this.props.onSelect(results[clickedIndex]);
-    }
-    this.setState({
-      results: [],
-      selectedIndex: 0
-    });
   }
 
   render() {
@@ -171,7 +165,7 @@ class FuzzySearch extends Component {
         {
           this.state.results && this.state.results.length > 0 &&
           <div style={styles.resultsWrapperStyle} >
-            {resultsTemplate(this.props, this.state, styles, this.handleMouseClick)}
+            {resultsTemplate(this.props, this.state, styles)}
           </div>
         }
       </div>

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,8 @@ const styles = {
     padding: '12px',
     borderTop: '1px solid #eee',
     color: '#666',
-    fontSize: 14
+    fontSize: 14,
+    cursor: 'pointer'
   },
   selectedResultStyle: {
     backgroundColor: '#f9f9f9',
@@ -35,7 +36,8 @@ const styles = {
     padding: '12px',
     borderTop: '1px solid #eee',
     color: '#666',
-    fontSize: 14
+    fontSize: 14,
+    cursor: 'pointer'
   },
   resultsWrapperStyle: {
     width: '100%',
@@ -49,10 +51,10 @@ const styles = {
   }
 };
 
-const defaultResultsTemplate = (props, state, styl) => {
+const defaultResultsTemplate = (props, state, styl, clickHandler) => {
   return state.results.map((val, i) => {
     const style = state.selectedIndex === i ? styl.selectedResultStyle : styl.resultsStyle;
-    return <div key={i} style={style} >{val.title}</div>;
+    return <div key={i} style={style} onClick={() => clickHandler(i)}>{val.title}</div>;
   });
 };
 
@@ -65,6 +67,7 @@ class FuzzySearch extends Component {
     };
     this.handleChange = this.handleChange.bind(this);
     this.handleKeyDown = this.handleKeyDown.bind(this);
+    this.handleMouseClick = this.handleMouseClick.bind(this);
     this.fuse = new Fuse(props.list, this.getOptions());
   }
 
@@ -100,14 +103,6 @@ class FuzzySearch extends Component {
     };
   }
 
-  getResultsTemplate() {
-    return this.state.results.map((val, i) => {
-      const style = this.state.selectedIndex === i ?
-        styles.selectedResultStyle : styles.resultsStyle;
-      return <div key={i} style={style} >{val.title}</div>;
-    });
-  }
-
   handleChange(e) {
     this.setState({
       results: this.fuse.search(e.target.value).slice(0, this.props.maxResults - 1)
@@ -133,6 +128,17 @@ class FuzzySearch extends Component {
         selectedIndex: 0
       });
     }
+  }
+
+  handleMouseClick(clickedIndex) {
+    const { results } = this.state;
+    if (results[clickedIndex]) {
+      this.props.onSelect(results[clickedIndex]);
+    }
+    this.setState({
+      results: [],
+      selectedIndex: 0
+    });
   }
 
   render() {
@@ -165,7 +171,7 @@ class FuzzySearch extends Component {
         {
           this.state.results && this.state.results.length > 0 &&
           <div style={styles.resultsWrapperStyle} >
-            {resultsTemplate(this.props, this.state, styles)}
+            {resultsTemplate(this.props, this.state, styles, this.handleMouseClick)}
           </div>
         }
       </div>

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,8 @@ const styles = {
     padding: '12px',
     borderTop: '1px solid #eee',
     color: '#666',
-    fontSize: 14
+    fontSize: 14,
+    cursor: 'pointer'
   },
   selectedResultStyle: {
     backgroundColor: '#f9f9f9',
@@ -35,7 +36,8 @@ const styles = {
     padding: '12px',
     borderTop: '1px solid #eee',
     color: '#666',
-    fontSize: 14
+    fontSize: 14,
+    cursor: 'pointer'
   },
   resultsWrapperStyle: {
     width: '100%',
@@ -49,10 +51,10 @@ const styles = {
   }
 };
 
-const defaultResultsTemplate = (props, state, styl) => {
+const defaultResultsTemplate = (props, state, styl, clickHandler) => {
   return state.results.map((val, i) => {
     const style = state.selectedIndex === i ? styl.selectedResultStyle : styl.resultsStyle;
-    return <div key={i} style={style} >{val.title}</div>;
+    return <div key={i} style={style} onClick={() => clickHandler(i)}>{val.title}</div>;
   });
 };
 
@@ -65,6 +67,7 @@ class FuzzySearch extends Component {
     };
     this.handleChange = this.handleChange.bind(this);
     this.handleKeyDown = this.handleKeyDown.bind(this);
+    this.handleMouseClick = this.handleMouseClick.bind(this);
     this.fuse = new Fuse(props.list, this.getOptions());
   }
 
@@ -135,6 +138,18 @@ class FuzzySearch extends Component {
     }
   }
 
+  handleMouseClick(clickedIndex) {
+    const { results } = this.state;
+
+    if (results[clickedIndex]) {
+      this.props.onSelect(results[clickedIndex]);
+    }
+    this.setState({
+      results: [],
+      selectedIndex: 0
+    });
+  }
+
   render() {
     const {
       className,
@@ -165,7 +180,7 @@ class FuzzySearch extends Component {
         {
           this.state.results && this.state.results.length > 0 &&
           <div style={styles.resultsWrapperStyle} >
-            {resultsTemplate(this.props, this.state, styles)}
+            {resultsTemplate(this.props, this.state, styles, this.handleMouseClick)}
           </div>
         }
       </div>

--- a/src/stories/index.js
+++ b/src/stories/index.js
@@ -63,13 +63,14 @@ storiesOf('SearchBox', module)
     />
   ))
   .add('Custom Template', () => {
-    function x(props, state, styles) {
+    function x(props, state, styles, clickHandler) {
       return state.results.map((val, i) => {
         const style = state.selectedIndex === i ? styles.selectedResultStyle : styles.resultsStyle;
         return (
           <div
             key={i}
             style={style}
+            onClick={() => clickHandler(i)}
           >
             {val.title}
             <span style={{ float: 'right', opacity: 0.5 }}>by {val.author}</span>

--- a/src/stories/index.js
+++ b/src/stories/index.js
@@ -63,13 +63,14 @@ storiesOf('SearchBox', module)
     />
   ))
   .add('Custom Template', () => {
-    function x(props, state, styles) {
+    function x(props, state, styles, mouseHandler) {
       return state.results.map((val, i) => {
         const style = state.selectedIndex === i ? styles.selectedResultStyle : styles.resultsStyle;
         return (
           <div
             key={i}
             style={style}
+            onClick={() => mouseHandler(i)}
           >
             {val.title}
             <span style={{ float: 'right', opacity: 0.5 }}>by {val.author}</span>

--- a/src/stories/index.js
+++ b/src/stories/index.js
@@ -63,14 +63,13 @@ storiesOf('SearchBox', module)
     />
   ))
   .add('Custom Template', () => {
-    function x(props, state, styles, clickHandler) {
+    function x(props, state, styles) {
       return state.results.map((val, i) => {
         const style = state.selectedIndex === i ? styles.selectedResultStyle : styles.resultsStyle;
         return (
           <div
             key={i}
             style={style}
-            onClick={() => clickHandler(i)}
           >
             {val.title}
             <span style={{ float: 'right', opacity: 0.5 }}>by {val.author}</span>

--- a/src/stories/index.js
+++ b/src/stories/index.js
@@ -63,14 +63,14 @@ storiesOf('SearchBox', module)
     />
   ))
   .add('Custom Template', () => {
-    function x(props, state, styles, mouseHandler) {
+    function x(props, state, styles, clickHandler) {
       return state.results.map((val, i) => {
         const style = state.selectedIndex === i ? styles.selectedResultStyle : styles.resultsStyle;
         return (
           <div
             key={i}
             style={style}
-            onClick={() => mouseHandler(i)}
+            onClick={() => clickHandler(i)}
           >
             {val.title}
             <span style={{ float: 'right', opacity: 0.5 }}>by {val.author}</span>


### PR DESCRIPTION
Issue : #4 
Add basic mouse click handler to results template.
If wanna use onTap instead of onClick, just create custom result template.

```js
<FuzzySearch
  list={list}
  keys={['author', 'title']}
  width={430}
  onSelect={action('selected')}
  resultsTemplate={(props, state, styles, clickHandler) => {
    return state.results.map((val, i) => {
      const style = state.selectedIndex === i ? styles.selectedResultStyle : styles.resultsStyle;
      return (
        <div
          key={i}
          style={style}
          {/*onClick={() => clickHandler(i)}*/}
          onTap={() => clickHandler(i)}
        >
          {val.title}
          <span style={{ float: 'right', opacity: 0.5 }}>by {val.author}</span>
        </div>
      );
    });
  }}
/>
```
