### PR TITLE
add options passthrough, stories, and test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-fuzzy",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "React Fuzzy Component",
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -85,6 +85,7 @@ export default class FuzzySearch extends Component {
     verbose: PropTypes.bool,
     autoFocus: PropTypes.bool,
     maxResults: PropTypes.number,
+    options: PropTypes.object,
   };
 
   static defaultProps = {
@@ -133,6 +134,7 @@ export default class FuzzySearch extends Component {
       distance,
       threshold,
       location,
+      options,
     } = this.props;
 
     return {
@@ -148,6 +150,7 @@ export default class FuzzySearch extends Component {
       distance,
       threshold,
       location,
+      ...options,
     };
   }
 

--- a/src/stories/index.js
+++ b/src/stories/index.js
@@ -96,4 +96,27 @@ storiesOf('SearchBox', module)
         placeholder="I am custom placeholder"
       />
     );
+  })
+  .add('Passthrough Options', () => {
+    const template = (props, state, styles, click) =>
+      state.results.map(({ item, matches }, i) => {
+        const style = state.selectedIndex === i ? styles.selectedResultStyle : styles.resultsStyle;
+        return (
+          <div key={i} style={style} onClick={() => click(i)}>
+            {item.title}
+            <span style={{ float: 'right', opacity: 0.5 }}>by {item.author}</span>
+          </div>
+        );
+      });
+
+    return (
+      <FuzzySearch
+        list={list}
+        keys={['author', 'title']}
+        width={430}
+        onSelect={action('selected')}
+        options={{ includeMatches: true }}
+        resultsTemplate={template}
+      />
+    );
   });

--- a/src/tests/index.js
+++ b/src/tests/index.js
@@ -97,4 +97,26 @@ describe('<FuzzySearch />', () => {
 
     expect(onChange.calledOnce).to.equal(true);
   });
+
+  it('shold overwrite previous props with options passed in', () => {
+    const onChange = sinon.spy();
+    const wrapper = mount(
+      <FuzzySearch
+        list={list}
+        onSelect={onChange}
+        keys={['author', 'title']}
+        options={{ includeMatches: true }}
+      />,
+    );
+
+    const input = wrapper.ref('searchBox');
+    input.simulate('change', {
+      target: {
+        value: 't',
+      },
+    });
+
+    // Each result should have a 'matches' array now with `includeMatches`
+    expect(wrapper.state('results')[0].matches.length).to.not.equal(0);
+  });
 });


### PR DESCRIPTION
I added the ability for you to pass an `options` object, and it will pile it on at the end after all your settings, that way it can be added without being a breaking change.

I don't know if something changed in a patch version of fuse or what, but one of your unit tests was failing when I ran it.

```
  1) <FuzzySearch /> should set results as ids if passed in options:

      AssertionError: expected [ '2', '1' ] to deeply equal [ 2, 1 ]
      + expected - actual

       [
      -  "2"
      -  "1"
      +  2
      +  1
       ]

      at Context.<anonymous> (src/tests/index.js:74:41)
```

Fixes #20 