### PR TITLE
Add `shouldFillInputWithSelection` prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ keys|all[Array]|List of properties that will be searched. This also supports nes
 list|null|Array of properties to be filtered.
 placeholder|'Search'|Placeholder of the searchbox
 resultsTemplate| Func | Template of the dropdown divs
+shouldFillInputWithSelection| false | Determines whether or not to sync the input value with the current selection.
 shouldSort| true | Whether to sort the result list, by score.
 sortFn|`Array.prototype.sort`|The function that is used for sorting the result list.
 threshold|0.6|At what point does the match algorithm give up. A threshold of `0.0` requires a perfect match (of both letters and location), a threshold of `1.0` would match anything.

--- a/src/index.js
+++ b/src/index.js
@@ -79,6 +79,7 @@ export default class FuzzySearch extends Component {
     location: PropTypes.number,
     placeholder: PropTypes.string,
     resultsTemplate: PropTypes.func,
+    shouldFillInputWithSelection: PropTypes.bool,
     shouldSort: PropTypes.bool,
     sortFn: PropTypes.func,
     threshold: PropTypes.number,
@@ -103,6 +104,7 @@ export default class FuzzySearch extends Component {
     width: 430,
     placeholder: 'Search',
     resultsTemplate: defaultResultsTemplate,
+    shouldFillInputWithSelection: false,
     shouldSort: true,
     sortFn(a, b) {
       return a.score - b.score;
@@ -124,7 +126,6 @@ export default class FuzzySearch extends Component {
     this.state = {
       results: [],
       selectedIndex: 0,
-      selectedValue: {},
       value: '',
     };
     this.handleChange = this.handleChange.bind(this);
@@ -174,6 +175,27 @@ export default class FuzzySearch extends Component {
     });
   }
 
+  selectItem(index) {
+    const { results } = this.state;
+    const { keyForDisplayName, onSelect, shouldFillInputWithSelection } = this.props
+
+    const selectedIndex = index || this.state.selectedIndex;
+    const result = results[selectedIndex];
+    if (result) {
+      // send result to onSelectMethod
+      onSelect(result);
+      // and set it as input value
+      this.setState({
+        value: shouldFillInputWithSelection ? (result[keyForDisplayName] || result) : ''
+      });
+    }
+    // hide dropdown
+    this.setState({
+      results: [],
+      selectedIndex: 0,
+    });
+  }
+
   handleKeyDown(e) {
     const { results, selectedIndex } = this.state;
 
@@ -191,31 +213,12 @@ export default class FuzzySearch extends Component {
 
       // Handle ENTER
     } else if (e.keyCode === 13) {
-      if (results[selectedIndex]) {
-        this.props.onSelect(results[this.state.selectedIndex]);
-        this.setState({
-          selectedValue: results[this.state.selectedIndex],
-        });
-      }
-      this.setState({
-        results: [],
-        selectedIndex: 0,
-        value: results[this.state.selectedIndex].item ? results[this.state.selectedIndex].item.value : '',
-      });
+      this.selectItem();
     }
   }
 
   handleMouseClick(clickedIndex) {
-    const { results } = this.state;
-
-    if (results[clickedIndex]) {
-      this.props.onSelect(results[clickedIndex]);
-    }
-    this.setState({
-      results: [],
-      selectedIndex: 0,
-      value: results[this.state.selectedIndex].item ? results[this.state.selectedIndex].item.value : '',
-    });
+    this.selectItem(clickedIndex);
   }
 
   render() {


### PR DESCRIPTION
Adds ability to sync the input value with the current selected item.

Rebased and blocked the feature behind a prop from https://github.com/ritz078/react-fuzzy-search/pull/26, thanks @master-elodin!

attribute|default|description
---------|-------|-----------
shouldFillInputWithSelection| false | Determines whether or not to sync the input value with the current selection.

Closes https://github.com/ritz078/react-fuzzy-search/issues/25, closes https://github.com/ritz078/react-fuzzy-search/issues/27