### PR TITLE
Add React 17 and 18 to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "webpack-hot-middleware": "^2.18.0"
   },
   "peerDependencies": {
-    "react": "^0.14.7 || ^15.0.0 || ^16.0.0"
+    "react": "^0.14.7 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {
     "prop-types": "^15.5.9",


### PR DESCRIPTION
This PR adds React 17 and 18 to peerDependencies. We've been using it on React 17 and haven't run into any issues, but would like to silence the peer dependency mismatch warnings 🙂  I don't see anything that would be an issue in React 18 so I added that as well.